### PR TITLE
Fix login reload loop

### DIFF
--- a/src/contexts/BlogContext.tsx
+++ b/src/contexts/BlogContext.tsx
@@ -32,7 +32,12 @@ export const BlogProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [currentBlog, setCurrentBlog] = useState<Blog | null>(null);
   const { isAuthenticated } = useAuth();
 
-  const { data: blogs = [], isLoading: loading, error, refetch } = useBlogs();
+  const {
+    data: blogs = [],
+    isLoading: loading,
+    error,
+    refetch,
+  } = useBlogs({ enabled: isAuthenticated });
 
   useEffect(() => {
     if (blogs.length > 0 && !currentBlog) {

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -32,7 +32,7 @@ apiClient.interceptors.response.use(
 );
 
 // Custom hooks for API operations
-export const useBlogs = () => {
+export const useBlogs = (options = {}) => {
   return useQuery({
     queryKey: ['blogs'],
     queryFn: async () => {
@@ -40,6 +40,7 @@ export const useBlogs = () => {
       return response.data.data;
     },
     staleTime: 5 * 60 * 1000, // 5 minutes
+    ...options,
   });
 };
 


### PR DESCRIPTION
## Summary
- avoid unconditional blogs request when user isn't authenticated
- make `useBlogs` accept query options

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6878e8b7ccf08322bbb9df50382cd51c