### PR TITLE
Fix OAuth callback authentication

### DIFF
--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -26,7 +26,7 @@ router.post('/change-password', authenticateToken, changePassword);
 router.get('/oauth/url', authenticateToken, getAuthUrl);
 
 // GET /api/admin/oauth/callback - Handle OAuth callback
-router.get('/oauth/callback', authenticateToken, handleOAuthCallback);
+router.get('/oauth/callback', handleOAuthCallback);
 
 // GET /api/admin/oauth/status - Check OAuth status
 router.get('/oauth/status', authenticateToken, getOAuthStatus);

--- a/backend/src/services/bloggerService.js
+++ b/backend/src/services/bloggerService.js
@@ -21,14 +21,15 @@ class BloggerService {
   }
 
   // Generate authorization URL for OAuth flow
-  async getAuthUrl() {
+  async getAuthUrl(state = '') {
     const scopes = ['https://www.googleapis.com/auth/blogger'];
-    
+
     return this.oauth2Client.generateAuthUrl({
       access_type: 'offline',
       scope: scopes,
       prompt: 'consent', // Force consent to get refresh token
-      include_granted_scopes: true
+      include_granted_scopes: true,
+      state
     });
   }
 


### PR DESCRIPTION
## Summary
- sign state token when generating Google OAuth URL
- accept state token in OAuth callback and decode user
- allow OAuth callback endpoint without requiring JWT
- include state when generating OAuth URL

## Testing
- `npm run lint` *(fails: 38 errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6878fb52be4c8322a0666ab0b318ca61