### PR TITLE
Fix OAuth token generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ Ikuti instruksi script:
 - Buka URL di browser dan login ke akun Google Anda
 - Copy authorization code dari URL callback
 - Paste code ke terminal
-- Script akan menyimpan refresh token ke database
+- Script akan otomatis menyimpan refresh token ke MongoDB
+  untuk admin sesuai `ADMIN_USERNAME` pada `.env`
 
 ### 4. Cara Mendapatkan Blog ID
 


### PR DESCRIPTION
## Summary
- store OAuth token in MongoDB for default admin
- clarify README OAuth token generation instructions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_687906e257a083229c3c26926aa99c54