### PR TITLE
Add global loading overlay

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-d
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './contexts/AuthContext';
 import { BlogProvider } from './contexts/BlogContext';
+import { LoadingProvider } from './contexts/LoadingContext';
 import ProtectedRoute from './components/ProtectedRoute';
 import Layout from './components/Layout';
 import Login from './pages/Login';
@@ -30,7 +31,8 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
         <BlogProvider>
-          <Router>
+          <LoadingProvider>
+            <Router>
             <div className="min-h-screen bg-gradient-to-br from-purple-600 to-blue-400">
               <Routes>
                 <Route path="/login" element={<Login />} />
@@ -87,7 +89,8 @@ function App() {
                 <Route path="*" element={<Navigate to="/404" replace />} />
               </Routes>
             </div>
-          </Router>
+            </Router>
+          </LoadingProvider>
         </BlogProvider>
       </AuthProvider>
     </QueryClientProvider>

--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const LoadingOverlay: React.FC = () => {
+  return (
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center">
+      <motion.div
+        className="glass-card p-8 flex flex-col items-center space-y-4"
+        initial={{ opacity: 0, scale: 0.8 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.3 }}
+      >
+        <div className="relative">
+          <div className="w-16 h-16 border-4 border-white/20 border-t-white/60 rounded-full animate-spin"></div>
+          <div className="absolute inset-0 w-16 h-16 border-4 border-transparent border-b-purple-300 rounded-full animate-spin"></div>
+        </div>
+        <p className="text-white/80 text-lg font-medium">Loading...</p>
+      </motion.div>
+    </div>
+  );
+};
+
+export default LoadingOverlay;

--- a/src/components/PageEditor.tsx
+++ b/src/components/PageEditor.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { Save, Eye, X, Calendar, Globe } from 'lucide-react';
 import RichTextEditor from './RichTextEditor';
 import { useCreatePage, useUpdatePage, usePage } from '../hooks/useApi';
+import { useLoading } from '../contexts/LoadingContext';
 
 interface PageEditorProps {
   pageId?: string;
@@ -21,6 +22,7 @@ const PageEditor: React.FC<PageEditorProps> = ({ pageId, isOpen, onClose, onSave
   const { data: existingPage } = usePage(pageId || '');
   const createPageMutation = useCreatePage();
   const updatePageMutation = useUpdatePage();
+  const { show, hide } = useLoading();
 
   useEffect(() => {
     if (existingPage) {
@@ -52,6 +54,7 @@ const PageEditor: React.FC<PageEditorProps> = ({ pageId, isOpen, onClose, onSave
     };
 
     try {
+      show();
       if (pageId) {
         await updatePageMutation.mutateAsync({ pageId, pageData });
         alert(publish ? 'Halaman berhasil dipublikasi' : 'Halaman berhasil disimpan');
@@ -64,6 +67,8 @@ const PageEditor: React.FC<PageEditorProps> = ({ pageId, isOpen, onClose, onSave
       onClose();
     } catch (error: any) {
       alert('Gagal menyimpan halaman: ' + (error.message || 'Unknown error'));
+    } finally {
+      hide();
     }
   };
 

--- a/src/components/PostEditor.tsx
+++ b/src/components/PostEditor.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { Save, Eye, X, Tag, Calendar, Globe } from 'lucide-react';
 import RichTextEditor from './RichTextEditor';
 import { useCreatePost, useUpdatePost, usePost } from '../hooks/useApi';
+import { useLoading } from '../contexts/LoadingContext';
 
 interface PostEditorProps {
   postId?: string;
@@ -23,6 +24,7 @@ const PostEditor: React.FC<PostEditorProps> = ({ postId, isOpen, onClose, onSave
   const { data: existingPost, isLoading: loadingPost } = usePost(postId || '');
   const createPostMutation = useCreatePost();
   const updatePostMutation = useUpdatePost();
+  const { show, hide } = useLoading();
 
   useEffect(() => {
     if (existingPost) {
@@ -58,6 +60,7 @@ const PostEditor: React.FC<PostEditorProps> = ({ postId, isOpen, onClose, onSave
     };
 
     try {
+      show();
       if (postId) {
         await updatePostMutation.mutateAsync({ postId, postData });
         alert(publish ? 'Postingan berhasil dipublikasi' : 'Postingan berhasil disimpan');
@@ -65,11 +68,13 @@ const PostEditor: React.FC<PostEditorProps> = ({ postId, isOpen, onClose, onSave
         await createPostMutation.mutateAsync(postData);
         alert(publish ? 'Postingan berhasil dipublikasi' : 'Draf berhasil disimpan');
       }
-      
+
       onSave?.();
       onClose();
     } catch (error: any) {
       alert('Gagal menyimpan postingan: ' + (error.message || 'Unknown error'));
+    } finally {
+      hide();
     }
   };
 

--- a/src/contexts/LoadingContext.tsx
+++ b/src/contexts/LoadingContext.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext, useState } from 'react';
+import LoadingOverlay from '../components/LoadingOverlay';
+
+interface LoadingContextType {
+  show: () => void;
+  hide: () => void;
+}
+
+const LoadingContext = createContext<LoadingContextType | undefined>(undefined);
+
+export const LoadingProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [visible, setVisible] = useState(false);
+
+  const show = () => setVisible(true);
+  const hide = () => setVisible(false);
+
+  return (
+    <LoadingContext.Provider value={{ show, hide }}>
+      {children}
+      {visible && <LoadingOverlay />}
+    </LoadingContext.Provider>
+  );
+};
+
+export const useLoading = () => {
+  const context = useContext(LoadingContext);
+  if (context === undefined) {
+    throw new Error('useLoading must be used within a LoadingProvider');
+  }
+  return context;
+};

--- a/src/pages/Comments.tsx
+++ b/src/pages/Comments.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import { MessageCircle, Search, Filter, Check, X, Flag, Calendar, User, AlertCircle } from 'lucide-react';
 import { useComments, useUpdateCommentStatus, useDeleteComment } from '../hooks/useApi';
+import { useLoading } from '../contexts/LoadingContext';
 
 const Comments: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
@@ -15,12 +16,18 @@ const Comments: React.FC = () => {
 
   const updateCommentMutation = useUpdateCommentStatus();
   const deleteCommentMutation = useDeleteComment();
+  const { show, hide } = useLoading();
 
-  const handleCommentAction = async (commentId: string, action: 'approve' | 'spam' | 'delete') => {
+  const handleCommentAction = async (
+    commentId: string,
+    action: 'approve' | 'spam' | 'delete',
+    withLoading = true
+  ) => {
     const comment = comments?.find((c: any) => c.id === commentId);
     if (!comment) return;
 
     try {
+      if (withLoading) show();
       if (action === 'delete') {
         await deleteCommentMutation.mutateAsync({
           commentId,
@@ -39,6 +46,8 @@ const Comments: React.FC = () => {
       }
     } catch (error) {
       alert('Gagal memproses komentar');
+    } finally {
+      if (withLoading) hide();
     }
   };
 
@@ -52,13 +61,16 @@ const Comments: React.FC = () => {
     if (!confirmed) return;
 
     try {
+      show();
       for (const commentId of selectedComments) {
-        await handleCommentAction(commentId, action);
+        await handleCommentAction(commentId, action, false);
       }
       setSelectedComments([]);
       alert(`${selectedComments.length} komentar berhasil diproses`);
     } catch (error) {
       alert('Gagal memproses beberapa komentar');
+    } finally {
+      hide();
     }
   };
 

--- a/src/pages/ContentLibrary.tsx
+++ b/src/pages/ContentLibrary.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import { Upload, Search, Filter, Image, Video, File, Trash2, Copy, Eye, Calendar, AlertCircle } from 'lucide-react';
 import { useContent, useUploadContent, useDeleteContent } from '../hooks/useApi';
+import { useLoading } from '../contexts/LoadingContext';
 
 const ContentLibrary: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
@@ -16,12 +17,14 @@ const ContentLibrary: React.FC = () => {
 
   const uploadMutation = useUploadContent();
   const deleteMutation = useDeleteContent();
+  const { show, hide } = useLoading();
 
   const handleFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
     if (!files || files.length === 0) return;
 
     try {
+      show();
       for (const file of files) {
         const formData = new FormData();
         formData.append('file', file);
@@ -30,6 +33,8 @@ const ContentLibrary: React.FC = () => {
       alert('File berhasil diupload');
     } catch (error) {
       alert('Gagal mengupload file');
+    } finally {
+      hide();
     }
 
     // Reset input
@@ -39,10 +44,13 @@ const ContentLibrary: React.FC = () => {
   const handleDelete = async (contentId: string) => {
     if (window.confirm('Apakah Anda yakin ingin menghapus file ini?')) {
       try {
+        show();
         await deleteMutation.mutateAsync(contentId);
         alert('File berhasil dihapus');
       } catch (error) {
         alert('Gagal menghapus file');
+      } finally {
+        hide();
       }
     }
   };
@@ -57,6 +65,7 @@ const ContentLibrary: React.FC = () => {
     if (!confirmed) return;
 
     try {
+      show();
       for (const fileId of selectedFiles) {
         await deleteMutation.mutateAsync(fileId);
       }
@@ -64,6 +73,8 @@ const ContentLibrary: React.FC = () => {
       alert(`${selectedFiles.length} file berhasil dihapus`);
     } catch (error) {
       alert('Gagal menghapus beberapa file');
+    } finally {
+      hide();
     }
   };
 

--- a/src/pages/Pages.tsx
+++ b/src/pages/Pages.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { Search, Plus, Edit, Trash2, Calendar, Eye, AlertCircle } from 'lucide-react';
 import { usePages, useDeletePage } from '../hooks/useApi';
 import PageEditor from '../components/PageEditor';
+import { useLoading } from '../contexts/LoadingContext';
 
 const Pages: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
@@ -12,6 +13,7 @@ const Pages: React.FC = () => {
 
   const { data: pages, isLoading, error, refetch } = usePages();
   const deletePageMutation = useDeletePage();
+  const { show, hide } = useLoading();
 
   const handleCreatePage = () => {
     setEditingPageId(undefined);
@@ -35,10 +37,13 @@ const Pages: React.FC = () => {
   const handleDelete = async (pageId: string) => {
     if (window.confirm('Apakah Anda yakin ingin menghapus halaman ini?')) {
       try {
+        show();
         await deletePageMutation.mutateAsync(pageId);
         alert('Halaman berhasil dihapus');
       } catch (error) {
         alert('Gagal menghapus halaman');
+      } finally {
+        hide();
       }
     }
   };

--- a/src/pages/Posts.tsx
+++ b/src/pages/Posts.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { Search, Filter, Plus, Edit, Trash2, Eye, Calendar, AlertCircle } from 'lucide-react';
 import { usePosts, useDeletePost } from '../hooks/useApi';
 import PostEditor from '../components/PostEditor';
+import { useLoading } from '../contexts/LoadingContext';
 
 const Posts: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
@@ -11,6 +12,7 @@ const Posts: React.FC = () => {
   const [isEditorOpen, setIsEditorOpen] = useState(false);
   const [editingPostId, setEditingPostId] = useState<string | undefined>();
   const postsPerPage = 10;
+  const { show, hide } = useLoading();
 
   const { data: postsData, isLoading, error, refetch } = usePosts({
     page: currentPage,
@@ -24,10 +26,13 @@ const Posts: React.FC = () => {
   const handleDelete = async (postId: string) => {
     if (window.confirm('Apakah Anda yakin ingin menghapus postingan ini?')) {
       try {
+        show();
         await deletePostMutation.mutateAsync(postId);
         alert('Postingan berhasil dihapus');
       } catch (error) {
         alert('Gagal menghapus postingan');
+      } finally {
+        hide();
       }
     }
   };


### PR DESCRIPTION
## Summary
- create a reusable `LoadingOverlay` component
- add `LoadingContext` for showing the loading overlay
- wrap the app with `LoadingProvider`
- show the overlay while posts, pages, comments, and content actions run
- display loading overlay when saving posts or pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6879cb198454832297e1756f5687d20f