### PR TITLE
Implement custom modal alerts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './contexts/AuthContext';
 import { BlogProvider } from './contexts/BlogContext';
 import { LoadingProvider } from './contexts/LoadingContext';
+import { ModalProvider } from './contexts/ModalContext';
 import ProtectedRoute from './components/ProtectedRoute';
 import Layout from './components/Layout';
 import Login from './pages/Login';
@@ -29,9 +30,10 @@ const queryClient = new QueryClient({
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <AuthProvider>
-        <BlogProvider>
-          <LoadingProvider>
+      <ModalProvider>
+        <AuthProvider>
+          <BlogProvider>
+            <LoadingProvider>
             <Router>
             <div className="min-h-screen bg-gradient-to-br from-purple-600 to-blue-400">
               <Routes>
@@ -90,9 +92,10 @@ function App() {
               </Routes>
             </div>
             </Router>
-          </LoadingProvider>
-        </BlogProvider>
-      </AuthProvider>
+            </LoadingProvider>
+          </BlogProvider>
+        </AuthProvider>
+      </ModalProvider>
     </QueryClientProvider>
   );
 }

--- a/src/components/PageEditor.tsx
+++ b/src/components/PageEditor.tsx
@@ -4,6 +4,7 @@ import { Save, Eye, X, Calendar, Globe } from 'lucide-react';
 import RichTextEditor from './RichTextEditor';
 import { useCreatePage, useUpdatePage, usePage } from '../hooks/useApi';
 import { useLoading } from '../contexts/LoadingContext';
+import { useModal } from '../contexts/ModalContext';
 
 interface PageEditorProps {
   pageId?: string;
@@ -23,6 +24,7 @@ const PageEditor: React.FC<PageEditorProps> = ({ pageId, isOpen, onClose, onSave
   const createPageMutation = useCreatePage();
   const updatePageMutation = useUpdatePage();
   const { show, hide } = useLoading();
+  const { alert } = useModal();
 
   useEffect(() => {
     if (existingPage) {
@@ -38,12 +40,12 @@ const PageEditor: React.FC<PageEditorProps> = ({ pageId, isOpen, onClose, onSave
 
   const handleSave = async (publish = false) => {
     if (!title.trim()) {
-      alert('Judul halaman tidak boleh kosong');
+      await alert('Judul halaman tidak boleh kosong');
       return;
     }
 
     if (!content.trim()) {
-      alert('Konten halaman tidak boleh kosong');
+      await alert('Konten halaman tidak boleh kosong');
       return;
     }
 
@@ -57,16 +59,16 @@ const PageEditor: React.FC<PageEditorProps> = ({ pageId, isOpen, onClose, onSave
       show();
       if (pageId) {
         await updatePageMutation.mutateAsync({ pageId, pageData });
-        alert(publish ? 'Halaman berhasil dipublikasi' : 'Halaman berhasil disimpan');
+        await alert(publish ? 'Halaman berhasil dipublikasi' : 'Halaman berhasil disimpan');
       } else {
         await createPageMutation.mutateAsync(pageData);
-        alert(publish ? 'Halaman berhasil dipublikasi' : 'Draf halaman berhasil disimpan');
+        await alert(publish ? 'Halaman berhasil dipublikasi' : 'Draf halaman berhasil disimpan');
       }
 
       onSave?.();
       onClose();
     } catch (error: any) {
-      alert('Gagal menyimpan halaman: ' + (error.message || 'Unknown error'));
+      await alert('Gagal menyimpan halaman: ' + (error.message || 'Unknown error'));
     } finally {
       hide();
     }

--- a/src/components/PostEditor.tsx
+++ b/src/components/PostEditor.tsx
@@ -4,6 +4,7 @@ import { Save, Eye, X, Tag, Calendar, Globe } from 'lucide-react';
 import RichTextEditor from './RichTextEditor';
 import { useCreatePost, useUpdatePost, usePost } from '../hooks/useApi';
 import { useLoading } from '../contexts/LoadingContext';
+import { useModal } from '../contexts/ModalContext';
 
 interface PostEditorProps {
   postId?: string;
@@ -25,6 +26,7 @@ const PostEditor: React.FC<PostEditorProps> = ({ postId, isOpen, onClose, onSave
   const createPostMutation = useCreatePost();
   const updatePostMutation = useUpdatePost();
   const { show, hide } = useLoading();
+  const { alert } = useModal();
 
   useEffect(() => {
     if (existingPost) {
@@ -43,12 +45,12 @@ const PostEditor: React.FC<PostEditorProps> = ({ postId, isOpen, onClose, onSave
 
   const handleSave = async (publish = false) => {
     if (!title.trim()) {
-      alert('Judul postingan tidak boleh kosong');
+      await alert('Judul postingan tidak boleh kosong');
       return;
     }
 
     if (!content.trim()) {
-      alert('Konten postingan tidak boleh kosong');
+      await alert('Konten postingan tidak boleh kosong');
       return;
     }
 
@@ -63,16 +65,16 @@ const PostEditor: React.FC<PostEditorProps> = ({ postId, isOpen, onClose, onSave
       show();
       if (postId) {
         await updatePostMutation.mutateAsync({ postId, postData });
-        alert(publish ? 'Postingan berhasil dipublikasi' : 'Postingan berhasil disimpan');
+        await alert(publish ? 'Postingan berhasil dipublikasi' : 'Postingan berhasil disimpan');
       } else {
         await createPostMutation.mutateAsync(postData);
-        alert(publish ? 'Postingan berhasil dipublikasi' : 'Draf berhasil disimpan');
+        await alert(publish ? 'Postingan berhasil dipublikasi' : 'Draf berhasil disimpan');
       }
 
       onSave?.();
       onClose();
     } catch (error: any) {
-      alert('Gagal menyimpan postingan: ' + (error.message || 'Unknown error'));
+      await alert('Gagal menyimpan postingan: ' + (error.message || 'Unknown error'));
     } finally {
       hide();
     }

--- a/src/components/RichTextEditor.tsx
+++ b/src/components/RichTextEditor.tsx
@@ -1,4 +1,5 @@
 import React, { useRef } from 'react';
+import { useModal } from '../contexts/ModalContext';
 import { Editor } from '@tinymce/tinymce-react';
 
 interface RichTextEditorProps {
@@ -15,6 +16,7 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
   placeholder = "Mulai menulis..."
 }) => {
   const editorRef = useRef<any>(null);
+  const { alert } = useModal();
 
   const handleEditorChange = (content: string) => {
     onChange(content);
@@ -186,18 +188,18 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
                     body: formData
                   })
                   .then(response => response.json())
-                  .then(result => {
+                  .then(async result => {
                     if (result.success) {
                       callback(result.data.url, {
                         alt: file.name,
                         title: file.name
                       });
                     } else {
-                      alert('Upload failed: ' + result.message);
+                      await alert('Upload failed: ' + result.message);
                     }
                   })
-                  .catch(error => {
-                    alert('Upload failed: ' + error.message);
+                  .catch(async error => {
+                    await alert('Upload failed: ' + error.message);
                   });
                 }
               });

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
 import axios from 'axios';
+import { useModal } from './ModalContext';
 
 interface User {
   id: string;
@@ -23,6 +24,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+  const { alert } = useModal();
 
   const checkAuthStatus = useCallback(async () => {
     try {
@@ -61,11 +63,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       
       // Handle specific error cases
       if (error.response?.status === 423) {
-        alert('Account is temporarily locked due to too many failed attempts. Please try again later.');
+        await alert('Account is temporarily locked due to too many failed attempts. Please try again later.');
       } else if (error.response?.status === 401) {
-        alert('Invalid username or password');
+        await alert('Invalid username or password');
       } else {
-        alert('Login failed. Please try again.');
+        await alert('Login failed. Please try again.');
       }
       
       return false;

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -1,0 +1,86 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+interface ModalContextType {
+  alert: (message: string) => Promise<void>;
+  confirm: (message: string) => Promise<boolean>;
+}
+
+interface ModalData {
+  type: 'alert' | 'confirm';
+  message: string;
+  resolve: (value: any) => void;
+}
+
+const ModalContext = createContext<ModalContextType | undefined>(undefined);
+
+export const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [modal, setModal] = useState<ModalData | null>(null);
+
+  const alert = (message: string) => {
+    return new Promise<void>((resolve) => {
+      setModal({ type: 'alert', message, resolve });
+      setTimeout(() => {
+        setModal(null);
+        resolve();
+      }, 1800);
+    });
+  };
+
+  const confirm = (message: string) => {
+    return new Promise<boolean>((resolve) => {
+      setModal({ type: 'confirm', message, resolve });
+    });
+  };
+
+  const handleConfirm = (value: boolean) => {
+    if (modal && modal.type === 'confirm') {
+      modal.resolve(value);
+      setModal(null);
+    }
+  };
+
+  return (
+    <ModalContext.Provider value={{ alert, confirm }}>
+      {children}
+      <AnimatePresence>
+        {modal && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+            <motion.div
+              initial={{ opacity: 0, scale: 0.9 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.9 }}
+              className="glass-card p-6 text-center max-w-xs"
+            >
+              <p className="text-white mb-4 whitespace-pre-line">{modal.message}</p>
+              {modal.type === 'confirm' && (
+                <div className="flex justify-center space-x-4">
+                  <button
+                    onClick={() => handleConfirm(false)}
+                    className="glass-button px-4 py-2 text-white rounded-lg"
+                  >
+                    Batal
+                  </button>
+                  <button
+                    onClick={() => handleConfirm(true)}
+                    className="bg-gradient-to-r from-purple-500 to-blue-500 px-4 py-2 text-white rounded-lg"
+                  >
+                    Ya
+                  </button>
+                </div>
+              )}
+            </motion.div>
+          </div>
+        )}
+      </AnimatePresence>
+    </ModalContext.Provider>
+  );
+};
+
+export const useModal = () => {
+  const context = useContext(ModalContext);
+  if (!context) {
+    throw new Error('useModal must be used within a ModalProvider');
+  }
+  return context;
+};

--- a/src/pages/Comments.tsx
+++ b/src/pages/Comments.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { MessageCircle, Search, Filter, Check, X, Flag, Calendar, User, AlertCircle } from 'lucide-react';
 import { useComments, useUpdateCommentStatus, useDeleteComment } from '../hooks/useApi';
 import { useLoading } from '../contexts/LoadingContext';
+import { useModal } from '../contexts/ModalContext';
 
 const Comments: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
@@ -17,6 +18,7 @@ const Comments: React.FC = () => {
   const updateCommentMutation = useUpdateCommentStatus();
   const deleteCommentMutation = useDeleteComment();
   const { show, hide } = useLoading();
+  const { alert, confirm } = useModal();
 
   const handleCommentAction = async (
     commentId: string,
@@ -34,7 +36,7 @@ const Comments: React.FC = () => {
           blogId: comment.blogId,
           postId: comment.postId
         });
-        alert('Komentar berhasil dihapus');
+        await alert('Komentar berhasil dihapus');
       } else {
         await updateCommentMutation.mutateAsync({
           commentId,
@@ -42,10 +44,10 @@ const Comments: React.FC = () => {
           blogId: comment.blogId,
           postId: comment.postId
         });
-        alert(`Komentar berhasil ${action === 'approve' ? 'disetujui' : 'ditandai sebagai spam'}`);
+        await alert(`Komentar berhasil ${action === 'approve' ? 'disetujui' : 'ditandai sebagai spam'}`);
       }
     } catch (error) {
-      alert('Gagal memproses komentar');
+      await alert('Gagal memproses komentar');
     } finally {
       if (withLoading) hide();
     }
@@ -54,7 +56,7 @@ const Comments: React.FC = () => {
   const handleBulkAction = async (action: 'approve' | 'spam' | 'delete') => {
     if (selectedComments.length === 0) return;
 
-    const confirmed = window.confirm(
+    const confirmed = await confirm(
       `Apakah Anda yakin ingin ${action === 'approve' ? 'menyetujui' : action === 'spam' ? 'menandai sebagai spam' : 'menghapus'} ${selectedComments.length} komentar?`
     );
 
@@ -66,9 +68,9 @@ const Comments: React.FC = () => {
         await handleCommentAction(commentId, action, false);
       }
       setSelectedComments([]);
-      alert(`${selectedComments.length} komentar berhasil diproses`);
+      await alert(`${selectedComments.length} komentar berhasil diproses`);
     } catch (error) {
-      alert('Gagal memproses beberapa komentar');
+      await alert('Gagal memproses beberapa komentar');
     } finally {
       hide();
     }

--- a/src/pages/ContentLibrary.tsx
+++ b/src/pages/ContentLibrary.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { Upload, Search, Filter, Image, Video, File, Trash2, Copy, Eye, Calendar, AlertCircle } from 'lucide-react';
 import { useContent, useUploadContent, useDeleteContent } from '../hooks/useApi';
 import { useLoading } from '../contexts/LoadingContext';
+import { useModal } from '../contexts/ModalContext';
 
 const ContentLibrary: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
@@ -18,6 +19,7 @@ const ContentLibrary: React.FC = () => {
   const uploadMutation = useUploadContent();
   const deleteMutation = useDeleteContent();
   const { show, hide } = useLoading();
+  const { alert, confirm } = useModal();
 
   const handleFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
@@ -30,9 +32,9 @@ const ContentLibrary: React.FC = () => {
         formData.append('file', file);
         await uploadMutation.mutateAsync(formData);
       }
-      alert('File berhasil diupload');
+      await alert('File berhasil diupload');
     } catch (error) {
-      alert('Gagal mengupload file');
+      await alert('Gagal mengupload file');
     } finally {
       hide();
     }
@@ -42,23 +44,23 @@ const ContentLibrary: React.FC = () => {
   };
 
   const handleDelete = async (contentId: string) => {
-    if (window.confirm('Apakah Anda yakin ingin menghapus file ini?')) {
-      try {
-        show();
-        await deleteMutation.mutateAsync(contentId);
-        alert('File berhasil dihapus');
-      } catch (error) {
-        alert('Gagal menghapus file');
-      } finally {
-        hide();
-      }
+    const confirmed = await confirm('Apakah Anda yakin ingin menghapus file ini?');
+    if (!confirmed) return;
+    try {
+      show();
+      await deleteMutation.mutateAsync(contentId);
+      await alert('File berhasil dihapus');
+    } catch (error) {
+      await alert('Gagal menghapus file');
+    } finally {
+      hide();
     }
   };
 
   const handleBulkDelete = async () => {
     if (selectedFiles.length === 0) return;
 
-    const confirmed = window.confirm(
+    const confirmed = await confirm(
       `Apakah Anda yakin ingin menghapus ${selectedFiles.length} file?`
     );
 
@@ -70,9 +72,9 @@ const ContentLibrary: React.FC = () => {
         await deleteMutation.mutateAsync(fileId);
       }
       setSelectedFiles([]);
-      alert(`${selectedFiles.length} file berhasil dihapus`);
+      await alert(`${selectedFiles.length} file berhasil dihapus`);
     } catch (error) {
-      alert('Gagal menghapus beberapa file');
+      await alert('Gagal menghapus beberapa file');
     } finally {
       hide();
     }
@@ -100,9 +102,9 @@ const ContentLibrary: React.FC = () => {
     }
   };
 
-  const copyToClipboard = (url: string) => {
+  const copyToClipboard = async (url: string) => {
     navigator.clipboard.writeText(url);
-    alert('URL berhasil disalin');
+    await alert('URL berhasil disalin');
   };
 
   const formatDate = (dateString: string) => {

--- a/src/pages/Pages.tsx
+++ b/src/pages/Pages.tsx
@@ -4,6 +4,7 @@ import { Search, Plus, Edit, Trash2, Calendar, Eye, AlertCircle } from 'lucide-r
 import { usePages, useDeletePage } from '../hooks/useApi';
 import PageEditor from '../components/PageEditor';
 import { useLoading } from '../contexts/LoadingContext';
+import { useModal } from '../contexts/ModalContext';
 
 const Pages: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
@@ -14,6 +15,7 @@ const Pages: React.FC = () => {
   const { data: pages, isLoading, error, refetch } = usePages();
   const deletePageMutation = useDeletePage();
   const { show, hide } = useLoading();
+  const { alert, confirm } = useModal();
 
   const handleCreatePage = () => {
     setEditingPageId(undefined);
@@ -35,16 +37,16 @@ const Pages: React.FC = () => {
   };
 
   const handleDelete = async (pageId: string) => {
-    if (window.confirm('Apakah Anda yakin ingin menghapus halaman ini?')) {
-      try {
-        show();
-        await deletePageMutation.mutateAsync(pageId);
-        alert('Halaman berhasil dihapus');
-      } catch (error) {
-        alert('Gagal menghapus halaman');
-      } finally {
-        hide();
-      }
+    const confirmed = await confirm('Apakah Anda yakin ingin menghapus halaman ini?');
+    if (!confirmed) return;
+    try {
+      show();
+      await deletePageMutation.mutateAsync(pageId);
+      await alert('Halaman berhasil dihapus');
+    } catch (error) {
+      await alert('Gagal menghapus halaman');
+    } finally {
+      hide();
     }
   };
 

--- a/src/pages/Posts.tsx
+++ b/src/pages/Posts.tsx
@@ -4,6 +4,7 @@ import { Search, Filter, Plus, Edit, Trash2, Eye, Calendar, AlertCircle } from '
 import { usePosts, useDeletePost } from '../hooks/useApi';
 import PostEditor from '../components/PostEditor';
 import { useLoading } from '../contexts/LoadingContext';
+import { useModal } from '../contexts/ModalContext';
 
 const Posts: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
@@ -13,6 +14,7 @@ const Posts: React.FC = () => {
   const [editingPostId, setEditingPostId] = useState<string | undefined>();
   const postsPerPage = 10;
   const { show, hide } = useLoading();
+  const { alert, confirm } = useModal();
 
   const { data: postsData, isLoading, error, refetch } = usePosts({
     page: currentPage,
@@ -24,16 +26,16 @@ const Posts: React.FC = () => {
   const deletePostMutation = useDeletePost();
 
   const handleDelete = async (postId: string) => {
-    if (window.confirm('Apakah Anda yakin ingin menghapus postingan ini?')) {
-      try {
-        show();
-        await deletePostMutation.mutateAsync(postId);
-        alert('Postingan berhasil dihapus');
-      } catch (error) {
-        alert('Gagal menghapus postingan');
-      } finally {
-        hide();
-      }
+    const confirmed = await confirm('Apakah Anda yakin ingin menghapus postingan ini?');
+    if (!confirmed) return;
+    try {
+      show();
+      await deletePostMutation.mutateAsync(postId);
+      await alert('Postingan berhasil dihapus');
+    } catch (error) {
+      await alert('Gagal menghapus postingan');
+    } finally {
+      hide();
     }
   };
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -4,6 +4,7 @@ import { Globe, User, Shield, RefreshCw, CheckCircle, AlertCircle, ExternalLink,
 import { useBlog } from '../contexts/BlogContext';
 import { useAuth } from '../contexts/AuthContext';
 import axios from 'axios';
+import { useModal } from '../contexts/ModalContext';
 
 interface OAuthStatus {
   isAuthorized: boolean;
@@ -22,6 +23,7 @@ const Settings: React.FC = () => {
   const [oauthStatus, setOAuthStatus] = useState<OAuthStatus | null>(null);
   const [loadingOAuth, setLoadingOAuth] = useState(false);
   const [authUrl, setAuthUrl] = useState<string | null>(null);
+  const { alert } = useModal();
 
   interface Tab {
     id: 'blog' | 'oauth' | 'admin';
@@ -56,7 +58,7 @@ const Settings: React.FC = () => {
       const response = await axios.get('/api/admin/oauth/url');
       setAuthUrl(response.data.authUrl);
     } catch (error: any) {
-      alert('Failed to generate authorization URL: ' + (error.response?.data?.message || error.message));
+      await alert('Failed to generate authorization URL: ' + (error.response?.data?.message || error.message));
     } finally {
       setLoadingOAuth(false);
     }
@@ -74,9 +76,9 @@ const Settings: React.FC = () => {
     }
   };
 
-  const handleChangePassword = () => {
+  const handleChangePassword = async () => {
     // This would open a password change modal
-    alert('Password change functionality would be implemented here');
+    await alert('Password change functionality would be implemented here');
   };
 
   return (


### PR DESCRIPTION
## Summary
- introduce `ModalContext` with alert and confirm helpers
- wrap the app with `ModalProvider`
- replace native `alert`/`confirm` calls across the app
- show examples for posts and content library pages

## Testing
- `npm run build`
- `npm run lint` *(fails: unexpected any)*

------
https://chatgpt.com/codex/tasks/task_b_6879f304529083229560c14836ffe515