### PR TITLE
Fix PostEditor layout responsiveness

### DIFF
--- a/src/components/PageEditor.tsx
+++ b/src/components/PageEditor.tsx
@@ -165,19 +165,19 @@ const PageEditor: React.FC<PageEditorProps> = ({ pageId, isOpen, onClose, onSave
                   </div>
                 </div>
               ) : (
-                <div className="h-full p-4">
+                <div className="flex-1 p-4 flex flex-col overflow-hidden">
                   {isHtmlMode ? (
                     <textarea
                       value={content}
                       onChange={e => setContent(e.target.value)}
-                      className="w-full h-full bg-gray-800 text-white p-3 font-mono border border-white/20 rounded text-sm"
+                      className="w-full flex-1 bg-gray-800 text-white p-3 font-mono border border-white/20 rounded text-sm"
                     />
                   ) : (
                     <RichTextEditor
                       value={content}
                       onChange={setContent}
-                      height={window.innerHeight - 300}
                       placeholder="Mulai menulis halaman Anda..."
+                      className="flex-1"
                     />
                   )}
                 </div>
@@ -186,7 +186,7 @@ const PageEditor: React.FC<PageEditorProps> = ({ pageId, isOpen, onClose, onSave
           </div>
 
           {/* Sidebar */}
-          <div className="w-56 border-l border-white/10 p-4 overflow-y-auto">
+          <div className="w-48 border-l border-white/10 p-4 overflow-y-auto">
             <div className="mb-4">
               <h3 className="text-white font-medium mb-2 flex items-center text-sm">
                 <Calendar className="w-3 h-3 mr-1" />

--- a/src/components/PostEditor.tsx
+++ b/src/components/PostEditor.tsx
@@ -177,9 +177,9 @@ const PostEditor: React.FC<PostEditorProps> = ({ postId, isOpen, onClose, onSave
             </div>
 
             {/* Editor/Preview */}
-            <div className="flex-1 overflow-hidden">
+            <div className="flex-1 overflow-hidden flex flex-col">
               {isPreview ? (
-                <div className="h-full overflow-y-auto p-4">
+                <div className="flex-1 overflow-y-auto p-4">
                   <div className="prose prose-lg max-w-none">
                     <h1 className="text-white text-2xl font-bold mb-4">{title || 'Untitled'}</h1>
                     <div
@@ -189,19 +189,19 @@ const PostEditor: React.FC<PostEditorProps> = ({ postId, isOpen, onClose, onSave
                   </div>
                 </div>
               ) : (
-                <div className="h-full p-4">
+                <div className="flex-1 p-4 flex flex-col overflow-hidden">
                   {isHtmlMode ? (
                     <textarea
                       value={content}
                       onChange={e => setContent(e.target.value)}
-                      className="w-full h-full bg-gray-800 text-white p-3 font-mono border border-white/20 rounded text-sm"
+                      className="w-full flex-1 bg-gray-800 text-white p-3 font-mono border border-white/20 rounded text-sm"
                     />
                   ) : (
                     <RichTextEditor
                       value={content}
                       onChange={setContent}
-                      height={window.innerHeight - 300}
                       placeholder="Mulai menulis postingan Anda..."
+                      className="flex-1"
                     />
                   )}
                 </div>
@@ -210,7 +210,7 @@ const PostEditor: React.FC<PostEditorProps> = ({ postId, isOpen, onClose, onSave
           </div>
 
           {/* Sidebar */}
-          <div className="w-64 border-l border-white/10 p-4 overflow-y-auto">
+          <div className="w-48 border-l border-white/10 p-4 overflow-y-auto">
             {/* Status */}
             <div className="mb-4">
               <h3 className="text-white font-medium mb-2 flex items-center text-sm">

--- a/src/components/RichTextEditor.tsx
+++ b/src/components/RichTextEditor.tsx
@@ -5,15 +5,19 @@ import { Editor } from '@tinymce/tinymce-react';
 interface RichTextEditorProps {
   value: string;
   onChange: (content: string) => void;
-  height?: number;
   placeholder?: string;
+  /**
+   * Optional className to allow the editor container to flexibly
+   * fill available space when used inside flex layouts.
+   */
+  className?: string;
 }
 
 const RichTextEditor: React.FC<RichTextEditorProps> = ({
   value,
   onChange,
-  height = 400,
-  placeholder = "Mulai menulis..."
+  placeholder = "Mulai menulis...",
+  className = ''
 }) => {
   const editorRef = useRef<any>(null);
   const { alert } = useModal();
@@ -26,14 +30,14 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
   const apiKey = import.meta.env.VITE_TINYMCE_API_KEY || "qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc";
 
   return (
-    <div className="rich-text-editor">
+    <div className={`rich-text-editor h-full flex flex-col ${className}`}>
       <Editor
         apiKey={apiKey}
         onInit={(evt, editor) => editorRef.current = editor}
         value={value}
         onEditorChange={handleEditorChange}
-        init={{
-          height: height,
+          init={{
+            height: '100%',
           menubar: true,
           plugins: [
             // Core editing features


### PR DESCRIPTION
## Summary
- maximize editor space in `PostEditor` via flexbox
- expand `RichTextEditor` to use available height
- adjust sidebar widths
- keep `PageEditor` consistent with responsive editor area

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_68858d04658c8322824e238f2ea9c634